### PR TITLE
Update expires_on to be a number instead of a string timestamp

### DIFF
--- a/src/imds/azext_imds/imds.py
+++ b/src/imds/azext_imds/imds.py
@@ -48,7 +48,7 @@ class AppService2017IMDS(BaseHTTPRequestHandler):
         token = {
             "access_token": cli_token["accessToken"],
             "client_id": "",
-            "expires_on": str(payload["exp"])
+            "expires_on": payload["exp"],
             "not_before": str(payload["nbf"]),
             "resource": resource,
             "token_type": "Bearer",

--- a/src/imds/azext_imds/imds.py
+++ b/src/imds/azext_imds/imds.py
@@ -48,9 +48,7 @@ class AppService2017IMDS(BaseHTTPRequestHandler):
         token = {
             "access_token": cli_token["accessToken"],
             "client_id": "",
-            "expires_on": time.strftime(
-                "%m/%d/%Y %H:%M:%S +00:00", time.localtime(payload["exp"])
-            ),
+            "expires_on": str(payload["exp"])
             "not_before": str(payload["nbf"]),
             "resource": resource,
             "token_type": "Bearer",


### PR DESCRIPTION
Running `az imds start`, seeing this error when the Python app tries to get a token:

```
azure.core.exceptions.ClientAuthenticationError: DefaultAzureCredential failed to retrieve a token from the included credentials.
Attempted credentials:
	EnvironmentCredential: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.
Visit https://aka.ms/azsdk/python/identity/environmentcredential/troubleshoot to troubleshoot this issue.
	ManagedIdentityCredential: invalid literal for int() with base 10: '04/14/2025 22:34:01 +00:00'
To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azsdk/python/identity/defaultazurecredential/troubleshoot.
```

Test Plan

- Built the extension on my branch: https://github.com/idevelop/azure-cli-extension-imds/actions/runs/14491802718
- Installed it with `az extensions add` and started with `az imds start`
- Ran the local Python code that uses `DefaultAzureCredential`.
- Obtaining a token now works, and the service is up and running with tokens fetched from the local extension.

```
127.0.0.1 - - [16/Apr/2025 12:45:23] "GET /MSI/token?api-version=2017-09-01&resource=api://6fbd563d-532c-46c7-9f9a-b1f4465e87ff HTTP/1.1" 200 -
```